### PR TITLE
Use named export in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export PSDB_DB_NAME='[YOUR ORG]/[YOUR DB NAME]'
 ```
 
 ```javascript
-const PSDB = require('planetscale-node');
+const {PSDB} = require('planetscale-node');
 
 async function main() {
   const conn = new PSDB('main');


### PR DESCRIPTION
This changed in https://github.com/planetscale/planetscale-node/pull/9.