### PR TITLE
feat(build): Add BuildKite CI steps.

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+echo "steps:"
+
+for VERSION in 12 14 16; do
+  echo "  - name: \"node:$VERSION build and test %n\""
+  echo "    command: npm ci && npm run build --if-present && npm test"
+  echo "    plugins:"
+  echo "      - docker#v3.8.0:"
+  echo "          image: \"node:$VERSION-slim\""
+done

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,0 @@
-steps:
-- name: "node:12 build and test %n"
-  commands:
-    - "npm ci" 
-    - "npm run build --if-present"
-    - "npm test"
-  plugins:
-    - docker#v3.8.0:
-        image: "node:12-slim"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,9 @@
+steps:
+- name: "node:12 build and test %n"
+  commands:
+    - "npm ci" 
+    - "npm run build --if-present"
+    - "npm test"
+  plugins:
+    - docker#v3.8.0:
+        image: "node:12-slim"


### PR DESCRIPTION
Adds a templatized buildkite pipeline that creates a step per major version.

Works by using `.buildkite/pipeline.sh | buildkite-agent pipeline upload` as the initial pipeline step, as per [the example](https://github.com/buildkite/dynamic-pipeline-example/tree/16890224b4a51b013f37319e1590e0ab633c606c).

Yields this output, currently:
```yaml
steps:
  - name: "node:12 build and test %n"
    command: npm ci && npm run build --if-present && npm test
    plugins:
      - docker#v3.8.0:
          image: "node:12-slim"
  - name: "node:14 build and test %n"
    command: npm ci && npm run build --if-present && npm test
    plugins:
      - docker#v3.8.0:
          image: "node:14-slim"
  - name: "node:16 build and test %n"
    command: npm ci && npm run build --if-present && npm test
    plugins:
      - docker#v3.8.0:
          image: "node:16-slim"
```