### PR TITLE
Move to the new certificates endpoint and switch to ECDSA certificates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "planetscale-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "name": "planetscale-node",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
+        "@peculiar/webcrypto": "^1.2.0",
+        "@peculiar/x509": "^1.5.2",
         "mysql2": "^2.2.5",
-        "node-forge": "^0.10.0"
+        "nanoid": "^3.1.30"
       },
       "devDependencies": {
         "@types/node": "^15.12.2",
@@ -174,6 +177,238 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.0.38.tgz",
+      "integrity": "sha512-9ZPki4qr2SIwD6y9d7Fgi4tnL51cCEqIltHvr7muIO78itM4VxovrbOOWEbNc2a+nJyac0ubVLil3+/xebo6jQ==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "@peculiar/asn1-x509-attr": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.0.38.tgz",
+      "integrity": "sha512-0Yw0Qzbj61gWpXupkga4Ajv49RIwsgNwnfIh3smRVrz7dz1w+F3XpHisJczkX/kATIl7mgPP/8dPGXa7xNAONg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.0.38.tgz",
+      "integrity": "sha512-ooaxfw7mlzFjLbCF9GPnYzZXEpPijuqHPNRExoCQ6Kd1xikuLgC0ARUc1JSpKQU41tTS1o1y6QnqEgmOxCkAWQ==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.0.38.tgz",
+      "integrity": "sha512-Q7+nk0LrAmIRZizXfdNKtmYKaQyiDVYHizkaXsFwzn1CbcfAKonVWLGdaSlbSpk7dNEY5v2iZ+giG3CkgnUlmw==",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.0.38",
+        "@peculiar/asn1-pkcs8": "^2.0.38",
+        "@peculiar/asn1-rsa": "^2.0.38",
+        "@peculiar/asn1-schema": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.0.38.tgz",
+      "integrity": "sha512-FIlnwL/bLkGECPyMpD9HI95CdHTt7rSPjG3FSioiosF38thxE73oI/p3okUZsLUeZaAAjAoLHnakObx/CKPnwg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.0.38.tgz",
+      "integrity": "sha512-aX2ianKE6CK8kLYRNq+DLbZTDeYxcXrB+b7ukC+LA0TlRx8VS3/zekA5n4HizTmK4oineKzkYnmRzsjF3X15jg==",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.0.38",
+        "@peculiar/asn1-pfx": "^2.0.38",
+        "@peculiar/asn1-pkcs8": "^2.0.38",
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "@peculiar/asn1-x509-attr": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.0.38.tgz",
+      "integrity": "sha512-oH0Pw9ytOUJurvqBRAwpr1e87EfMUfySmeGSujWMUtdyYbuylmUZjVsUEZJEFfCV16uFwmuQ9P84jXFBTHiH7g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.38.tgz",
+      "integrity": "sha512-zZ64UpCTm9me15nuCpPgJghSdbEm8atcDQPCyK+bKXjZAQ1735NCZXCSCfbckbQ4MH36Rm9403n/qMq77LFDzQ==",
+      "dependencies": {
+        "@types/asn1js": "^2.0.2",
+        "asn1js": "^2.1.1",
+        "pvtsutils": "^1.2.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.0.38.tgz",
+      "integrity": "sha512-10aK9fSxlc1DK9nEcwh+WPFNhAheXSE9RbI5MyS7FdBhgq+Mz4Z9JqFfaBZm1Qp+5mPtUMOP6cXVo7aaYlgq7A==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "ipaddr.js": "^2.0.1",
+        "pvtsutils": "^1.2.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.0.38.tgz",
+      "integrity": "sha512-xjnQeijEZLPUN4/3uX/Fe41p/Lu6+Da8bU5erVn9M16Fi6GOiTiyra2eiYuzKpR3bUFbEOLHV3n+Xqn9NLiOIg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/json-schema/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.2.0.tgz",
+      "integrity": "sha512-ln2CvfmTzXSr877zM1+3JTyvbtaDXsoDivvEyeYAzB4RQIM+Pw82gp1nQFp9xM4BylBBrip/R36Gp+WJFCoU3Q==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.2.1",
+        "tslib": "^2.3.1",
+        "webcrypto-core": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.5.2.tgz",
+      "integrity": "sha512-GUDkI+sPUO6HNWgNULEUtH95Ud0gBIdc5hVS/OS3Nj0/KGJnAX+fsy1ef8NfeL9WrCjG1YLmzKl99RsePo7eIA==",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.0.38",
+        "@peculiar/asn1-csr": "^2.0.38",
+        "@peculiar/asn1-ecc": "^2.0.38",
+        "@peculiar/asn1-pkcs9": "^2.0.38",
+        "@peculiar/asn1-rsa": "^2.0.38",
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "pvtsutils": "^1.2.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.3.1",
+        "tsyringe": "^4.6.0"
+      }
+    },
+    "node_modules/@peculiar/x509/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@types/asn1js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.2.tgz",
+      "integrity": "sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
@@ -418,9 +653,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -457,6 +692,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
+      "integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
+      "dependencies": {
+        "pvutils": "latest"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/astral-regex": {
@@ -1134,6 +1380,14 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1351,19 +1605,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
+    "node_modules/nanoid": {
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -1498,6 +1755,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.2.1.tgz",
+      "integrity": "sha512-Q867jEr30lBR2YSFFLZ0/XsEvpweqH6Kj096wmlRAFXrdRGPCNq2iz9B5Tk085EZ+OBZyYAVA5UhPkjSHGrUzQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/pvutils": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1517,6 +1795,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/regexpp": {
       "version": "3.1.0",
@@ -1792,8 +2075,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -1808,6 +2090,17 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
+      "integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/type-check": {
@@ -1861,6 +2154,23 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.3.0.tgz",
+      "integrity": "sha512-/+Hz+uNM6T8FtizWRYMNdGTXxWaljLFzQ5GKU4WqCTZKpaki94YqDA39h/SpWxEZfgkVMZzrqqtPlfy2+BloQw==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^2.1.1",
+        "pvtsutils": "^1.2.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/webcrypto-core/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2026,6 +2336,258 @@
         "fastq": "^1.6.0"
       }
     },
+    "@peculiar/asn1-cms": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.0.38.tgz",
+      "integrity": "sha512-9ZPki4qr2SIwD6y9d7Fgi4tnL51cCEqIltHvr7muIO78itM4VxovrbOOWEbNc2a+nJyac0ubVLil3+/xebo6jQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "@peculiar/asn1-x509-attr": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-csr": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.0.38.tgz",
+      "integrity": "sha512-0Yw0Qzbj61gWpXupkga4Ajv49RIwsgNwnfIh3smRVrz7dz1w+F3XpHisJczkX/kATIl7mgPP/8dPGXa7xNAONg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-ecc": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.0.38.tgz",
+      "integrity": "sha512-ooaxfw7mlzFjLbCF9GPnYzZXEpPijuqHPNRExoCQ6Kd1xikuLgC0ARUc1JSpKQU41tTS1o1y6QnqEgmOxCkAWQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-pfx": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.0.38.tgz",
+      "integrity": "sha512-Q7+nk0LrAmIRZizXfdNKtmYKaQyiDVYHizkaXsFwzn1CbcfAKonVWLGdaSlbSpk7dNEY5v2iZ+giG3CkgnUlmw==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.0.38",
+        "@peculiar/asn1-pkcs8": "^2.0.38",
+        "@peculiar/asn1-rsa": "^2.0.38",
+        "@peculiar/asn1-schema": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-pkcs8": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.0.38.tgz",
+      "integrity": "sha512-FIlnwL/bLkGECPyMpD9HI95CdHTt7rSPjG3FSioiosF38thxE73oI/p3okUZsLUeZaAAjAoLHnakObx/CKPnwg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-pkcs9": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.0.38.tgz",
+      "integrity": "sha512-aX2ianKE6CK8kLYRNq+DLbZTDeYxcXrB+b7ukC+LA0TlRx8VS3/zekA5n4HizTmK4oineKzkYnmRzsjF3X15jg==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.0.38",
+        "@peculiar/asn1-pfx": "^2.0.38",
+        "@peculiar/asn1-pkcs8": "^2.0.38",
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "@peculiar/asn1-x509-attr": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-rsa": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.0.38.tgz",
+      "integrity": "sha512-oH0Pw9ytOUJurvqBRAwpr1e87EfMUfySmeGSujWMUtdyYbuylmUZjVsUEZJEFfCV16uFwmuQ9P84jXFBTHiH7g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.38.tgz",
+      "integrity": "sha512-zZ64UpCTm9me15nuCpPgJghSdbEm8atcDQPCyK+bKXjZAQ1735NCZXCSCfbckbQ4MH36Rm9403n/qMq77LFDzQ==",
+      "requires": {
+        "@types/asn1js": "^2.0.2",
+        "asn1js": "^2.1.1",
+        "pvtsutils": "^1.2.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-x509": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.0.38.tgz",
+      "integrity": "sha512-10aK9fSxlc1DK9nEcwh+WPFNhAheXSE9RbI5MyS7FdBhgq+Mz4Z9JqFfaBZm1Qp+5mPtUMOP6cXVo7aaYlgq7A==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "ipaddr.js": "^2.0.1",
+        "pvtsutils": "^1.2.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/asn1-x509-attr": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.0.38.tgz",
+      "integrity": "sha512-xjnQeijEZLPUN4/3uX/Fe41p/Lu6+Da8bU5erVn9M16Fi6GOiTiyra2eiYuzKpR3bUFbEOLHV3n+Xqn9NLiOIg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "asn1js": "^2.1.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.2.0.tgz",
+      "integrity": "sha512-ln2CvfmTzXSr877zM1+3JTyvbtaDXsoDivvEyeYAzB4RQIM+Pw82gp1nQFp9xM4BylBBrip/R36Gp+WJFCoU3Q==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.2.1",
+        "tslib": "^2.3.1",
+        "webcrypto-core": "^1.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@peculiar/x509": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.5.2.tgz",
+      "integrity": "sha512-GUDkI+sPUO6HNWgNULEUtH95Ud0gBIdc5hVS/OS3Nj0/KGJnAX+fsy1ef8NfeL9WrCjG1YLmzKl99RsePo7eIA==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.0.38",
+        "@peculiar/asn1-csr": "^2.0.38",
+        "@peculiar/asn1-ecc": "^2.0.38",
+        "@peculiar/asn1-pkcs9": "^2.0.38",
+        "@peculiar/asn1-rsa": "^2.0.38",
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/asn1-x509": "^2.0.38",
+        "pvtsutils": "^1.2.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.3.1",
+        "tsyringe": "^4.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@types/asn1js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.2.tgz",
+      "integrity": "sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA=="
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -2173,9 +2735,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -2201,6 +2763,14 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "asn1js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
+      "integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
+      "requires": {
+        "pvutils": "latest"
+      }
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -2714,6 +3284,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2897,16 +3472,16 @@
         }
       }
     },
+    "nanoid": {
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "once": {
       "version": "1.4.0",
@@ -3002,11 +3577,36 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "pvtsutils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.2.1.tgz",
+      "integrity": "sha512-Q867jEr30lBR2YSFFLZ0/XsEvpweqH6Kj096wmlRAFXrdRGPCNq2iz9B5Tk085EZ+OBZyYAVA5UhPkjSHGrUzQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "pvutils": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regexpp": {
       "version": "3.1.0",
@@ -3199,8 +3799,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -3209,6 +3808,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "tsyringe": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
+      "integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "type-check": {
@@ -3246,6 +3853,25 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "webcrypto-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.3.0.tgz",
+      "integrity": "sha512-/+Hz+uNM6T8FtizWRYMNdGTXxWaljLFzQ5GKU4WqCTZKpaki94YqDA39h/SpWxEZfgkVMZzrqqtPlfy2+BloQw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.0.38",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^2.1.1",
+        "pvtsutils": "^1.2.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "nanoid": "^3.1.30"
       },
       "devDependencies": {
-        "@types/node": "^15.12.2",
-        "@types/node-forge": "^0.10.0",
+        "@types/node": "^16.11.6",
         "@typescript-eslint/eslint-plugin": "^4.26.1",
         "@typescript-eslint/parser": "^4.26.1",
         "eslint": "^7.27.0",
@@ -417,19 +416,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "16.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
       "dev": true
-    },
-    "node_modules/@types/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-qxCPxN/6s/kY4Xud/1T6gIQtJjRz09UWSA8fTEfUXu4rC9EkFt4KA3s8bYLvkNJmIEWlVeuhZ1CFl7F5rp3FCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.26.1",
@@ -2595,19 +2585,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "16.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
       "dev": true
-    },
-    "@types/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-qxCPxN/6s/kY4Xud/1T6gIQtJjRz09UWSA8fTEfUXu4rC9EkFt4KA3s8bYLvkNJmIEWlVeuhZ1CFl7F5rp3FCA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.26.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "nanoid": "^3.1.30"
   },
   "devDependencies": {
-    "@types/node": "^15.12.2",
-    "@types/node-forge": "^0.10.0",
+    "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "eslint": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planetscale-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PlanetScale Database Client",
   "main": "dist/index.js",
   "types": "dist/index.d.js",
@@ -27,8 +27,10 @@
   },
   "homepage": "https://github.com/planetscale/planetscale-node#readme",
   "dependencies": {
+    "@peculiar/webcrypto": "^1.2.0",
+    "@peculiar/x509": "^1.5.2",
     "mysql2": "^2.2.5",
-    "node-forge": "^0.10.0"
+    "nanoid": "^3.1.30"
   },
   "devDependencies": {
     "@types/node": "^15.12.2",


### PR DESCRIPTION
This updates the logic to move to ECSDA certificates and use the new certificates endpoint that is a lot faster to sign CSR requests.

It also allows changing to the proper hostname with a correct certificate to enforce hostname validation and don't use insecure connections.

Supersedes #21 