### PR TITLE
Send User-Agent request header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ function postJSON<T>(
       Accept: 'application/json',
       'Content-Type': 'application/json',
       'Content-Length': json.length,
+      'User-Agent': 'planetscale-node/0.2.0',
       ...headers
     }
   }


### PR DESCRIPTION
The server responds with a 403 Forbidden status if this header is missing. Fixes #31.