### PR TITLE
fix: possible never solved promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,14 @@ function postJSON<T>(
     const req = https.request(options, (response) => {
       let body = ''
       response.on('data', (chunk) => (body += chunk))
-      response.on('end', () => resolve({ response, body: JSON.parse(body) }))
+      response.on('end', () => {
+        try {
+          const parsedBody = JSON.parse(body)
+          resolve({ response, body: parsedBody })
+        } catch (e) {
+          reject(e)
+        }
+      })
     })
 
     req.on('error', (e) => reject(e))


### PR DESCRIPTION
If the response body from the server is an invalid JSON the promise with the result will never be resolves as the parsing error will be thrown inside a listener